### PR TITLE
PF-643: Fix stripping whitespace for quotes in nested bullets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .rvmrc
 .ruby-version
 .ruby-gemset
-.codeclimate
 Gemfile.lock
 pkg/*
 coverage/*

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Transform html into markdown. Useful for example if you want to import html into your markdown based application.
 
-[![Build Status](https://secure.travis-ci.org/xijo/reverse_markdown.png?branch=master)](https://travis-ci.org/xijo/reverse_markdown) [![Gem Version](https://badge.fury.io/rb/reverse_markdown.png)](http://badge.fury.io/rb/reverse_markdown) [![Code Climate](https://codeclimate.com/github/xijo/reverse_markdown.png)](https://codeclimate.com/github/xijo/reverse_markdown) [![Code Climate](https://codeclimate.com/github/xijo/reverse_markdown/coverage.png)](https://codeclimate.com/github/xijo/reverse_markdown)
-
 ## Changelog
 
 See [Change Log](CHANGELOG.md)
@@ -35,7 +33,6 @@ gem 'reverse_markdown'
 - Inline and block code is supported
 - Supports blockquote
 
-
 # Usage
 
 ## Ruby
@@ -46,7 +43,7 @@ You can convert html content as string or Nokogiri document:
 input  = '<strong>feelings</strong>'
 result = ReverseMarkdown.convert input
 result.inspect # " **feelings** "
-````
+```
 
 ## Commandline
 
@@ -55,7 +52,7 @@ It's also possible to convert html files to markdown using the binary:
 ```sh
 $ reverse_markdown file.html > file.md
 $ cat file.html | reverse_markdown > file.md
-````
+```
 
 ## Configuration
 
@@ -87,7 +84,6 @@ ReverseMarkdown.config do |config|
 end
 ```
 
-
 # Related stuff
 
 - [Write custom converters](https://github.com/xijo/reverse_markdown/wiki/Write-your-own-converter) - Wiki entry about how to write your own converter
@@ -96,7 +92,6 @@ end
 - [markdown syntax](http://daringfireball.net/projects/markdown) - The markdown syntax specification
 - [github flavored markdown](https://help.github.com/articles/github-flavored-markdown) - Githubs extension to markdown
 - [wmd-editor](http://wmd-editor.com) - Markdown flavored text editor
-
 
 # Thanks
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,5 @@
 require 'bundler/gem_tasks'
 
-if File.exist?('.codeclimate')
-  ENV["CODECLIMATE_REPO_TOKEN"] = File.read('.codeclimate').strip
-end
-
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 task :default => :spec

--- a/lib/reverse_markdown/cleaner.rb
+++ b/lib/reverse_markdown/cleaner.rb
@@ -65,7 +65,7 @@ module ReverseMarkdown
     end
 
     def clean_punctuation_characters(string)
-      string.gsub(/(\*\*|~~|__)\s([\.!\?'"])/, "\\1".strip + "\\2")
+      string.gsub(/(?<!^)(\*\*|~~|__)\s([\.!\?'"])/, "\\1\\2")
     end
 
     private

--- a/reverse_markdown.gemspec
+++ b/reverse_markdown.gemspec
@@ -26,6 +26,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'redcarpet'
-  # s.add_development_dependency 'byebug'
-  s.add_development_dependency 'codeclimate-test-reporter'
 end

--- a/spec/lib/reverse_markdown/cleaner_spec.rb
+++ b/spec/lib/reverse_markdown/cleaner_spec.rb
@@ -49,9 +49,21 @@ describe ReverseMarkdown::Cleaner do
 
   describe '#clean_punctuation_characters' do
     it 'removes whitespace between tag end and punctuation characters' do
-      input = "**fat** . ~~strike~~ ? __italic__ ! "
+      input = "**fat** . ~~strike~~ ? \n__italic__ ! "
       result = cleaner.clean_punctuation_characters(input)
-      expect(result).to eq "**fat**. ~~strike~~? __italic__! "
+      expect(result).to eq "**fat**. ~~strike~~? \n__italic__! "
+    end
+
+    it 'handles a newline starting with bold text' do
+      input = "test **bold** !\n* test\n** \"asdf\"\nasdf asdf\n** \"My bold text\"** My not bold text"
+      result = cleaner.clean_punctuation_characters(input)
+      expect(result).to eq "test **bold**!\n* test\n** \"asdf\"\nasdf asdf\n** \"My bold text\"** My not bold text"
+    end
+
+    it 'keeps whitespace between bullets and punctuation' do
+      input = "** \"some quoted text\""
+      result = cleaner.clean_punctuation_characters(input)
+      expect(result).to eq input
     end
   end
 

--- a/spec/lib/reverse_markdown/converters/br_spec.rb
+++ b/spec/lib/reverse_markdown/converters/br_spec.rb
@@ -4,6 +4,6 @@ describe ReverseMarkdown::Converters::Br do
   let(:converter) { ReverseMarkdown::Converters::Br.new }
 
   it 'just converts into two spaces and a newline' do
-    expect(converter.convert(:anything)).to eq "  \n"
+    expect(converter.convert(:anything, 0)).to eq "  \n"
   end
 end

--- a/spec/lib/reverse_markdown/converters/del_spec.rb
+++ b/spec/lib/reverse_markdown/converters/del_spec.rb
@@ -8,12 +8,12 @@ describe ReverseMarkdown::Converters::Del do
 
     it 'converts the input as expected' do
       input = Nokogiri::XML.parse('<del>deldeldel</del>').root
-      expect(converter.convert(input)).to eq '~~deldeldel~~'
+      expect(converter.convert(input, 0)).to eq '~~deldeldel~~'
     end
 
     it 'skips empty tags' do
       input = Nokogiri::XML.parse('<del></del>').root
-      expect(converter.convert(input)).to eq ''
+      expect(converter.convert(input, 0)).to eq ''
     end
 
     it 'knows about its enabled/disabled state' do
@@ -27,7 +27,7 @@ describe ReverseMarkdown::Converters::Del do
 
     it 'does not convert anything' do
       input = Nokogiri::XML.parse('<del>deldeldel</del>').root
-      expect(converter.convert(input)).to eq 'deldeldel'
+      expect(converter.convert(input, 0)).to eq 'deldeldel'
     end
 
     it 'knows about its enabled/disabled state' do

--- a/spec/lib/reverse_markdown/converters/li_spec.rb
+++ b/spec/lib/reverse_markdown/converters/li_spec.rb
@@ -6,7 +6,7 @@ describe ReverseMarkdown::Converters::Li do
 
   it 'does not fail without a valid parent context' do
     input = Nokogiri::XML.parse("<li>foo</li>").root
-    result = converter.convert(input)
+    result = converter.convert(input, 0)
     expect(result).to eq "- foo\n"
   end
 

--- a/spec/lib/reverse_markdown/converters/text_spec.rb
+++ b/spec/lib/reverse_markdown/converters/text_spec.rb
@@ -6,25 +6,25 @@ describe ReverseMarkdown::Converters::Text do
 
   it 'treats newline within text as a single whitespace' do
     input = Nokogiri::XML.parse("<p>foo\nbar</p>").root
-    result = converter.convert(input)
+    result = converter.convert(input, 0)
     expect(result).to eq 'foo bar'
   end
 
   it 'removes leading newlines' do
     input = Nokogiri::XML.parse("<p>\n\nfoo bar</p>").root
-    result = converter.convert(input)
+    result = converter.convert(input, 0)
     expect(result).to eq 'foo bar'
   end
 
   it 'removes trailing newlines' do
     input = Nokogiri::XML.parse("<p>foo bar\n\n</p>").root
-    result = converter.convert(input)
+    result = converter.convert(input, 0)
     expect(result).to eq 'foo bar'
   end
 
   it 'keeps nbsps' do
     input = Nokogiri::XML.parse("<p>foo\u00A0bar \u00A0</p>").root
-    result = converter.convert(input)
+    result = converter.convert(input, 0)
     expect(result).to eq "foo&nbsp;bar &nbsp;"
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,4 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
-
 require 'simplecov'
-# require 'byebug'
 
 SimpleCov.adapters.define 'gem' do
   add_filter '/spec/'


### PR DESCRIPTION
First commit: just fixes the tests for a baseline https://github.com/aha-app/reverse_markdown/commit/f0d085e30d3352914cdfdff681ec04e72bc5e301
Second commit: the actual change https://github.com/aha-app/reverse_markdown/commit/04e4fb26205b5c3dc9c3345838a1f3afd8e0b719

We have some cleanup code which is supposed to remove extra whitespace between formatting and punctuation.

```
I have **bold** !
# becomes
I have **bold**!
```

Currently it is too aggressive because it doesn't realize `**` can mean a nested list:

```
* list
** "sublist starting with punctuation"
# becomes
* list
**"sublist starting with punctuation"
```

Removing the space after the `**` breaks the sublist. The PR adds a check that the match is not at the beginning of a line. It also changes `"\\1".strip + "\\2"` to just `"\\1\\2"` -- this is misleading because the strip only strips `"\\1`", not the actual matched string. The regex works because the match regions contain the desired content and exclude the whitespace we are discarding.